### PR TITLE
fetch-tags doesn't work but fetch-depth is enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       # Get the version and update the tags to use in the release
       - name: Tag Commit
@@ -122,7 +122,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
 
       # Use the version from the input variable
       - name: Create Release


### PR DESCRIPTION
Neither `fetch-tags: 'true'` nor `fetch-tags: true` works. They are not enough for `issue-ops/semver` to pick up an existing tag. But just setting `fetch-depth: 0` is enough.