### PR TITLE
Add api_url as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ jobs:
 
 | Input                    | Description                                                                               |
 | ------------------------ | ----------------------------------------------------------------------------------------- |
+| `api_url`                | The GitHub API URL to use                                                                 |
+|                          | Default: `${{ github.api_url }}`                                                          |
 | `draft`                  | Whether or not the release should be a draft                                              |
 |                          | Default: `false`                                                                          |
 | `generate_release_notes` | Whether or not to generate release notes                                                  |

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -25,7 +25,7 @@ describe('main.ts', () => {
   beforeEach(() => {
     // Set the action's inputs as return values from core.getInput()
     core.getInput
-      .mockReturnValueOnce('https://api.gihub.com') // api_url
+      .mockReturnValueOnce('https://api.github.com') // api_url
       .mockReturnValueOnce('false') // draft
       .mockReturnValueOnce('true') // generate_release_notes
       .mockReturnValueOnce('v1.0.0') // name

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -25,6 +25,7 @@ describe('main.ts', () => {
   beforeEach(() => {
     // Set the action's inputs as return values from core.getInput()
     core.getInput
+      .mockReturnValueOnce('https://api.gihub.com') // api_url
       .mockReturnValueOnce('false') // draft
       .mockReturnValueOnce('true') // generate_release_notes
       .mockReturnValueOnce('v1.0.0') // name
@@ -52,6 +53,7 @@ describe('main.ts', () => {
 
     await main.run()
 
+    expect(core.getInput).toHaveBeenCalledWith('api_url', { required: true })
     expect(core.getInput).toHaveBeenCalledWith('draft')
     expect(core.getInput).toHaveBeenCalledWith('generate_release_notes')
     expect(core.getInput).toHaveBeenCalledWith('name')
@@ -75,6 +77,7 @@ describe('main.ts', () => {
   it('Replaces name with tag when not present', async () => {
     core.getInput
       .mockClear()
+      .mockReturnValueOnce('https://api.gihub.com') // api_url
       .mockReturnValueOnce('false') // draft
       .mockReturnValueOnce('true') // generate_release_notes
       .mockReturnValueOnce('') // name

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ branding:
   color: blue
 
 inputs:
+  api_url:
+    description: The GitHub API URL to use.
+    required: false
+    default: ${{ github.api_url }}
   draft:
     description: Whether or not the release should be a draft.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -30829,6 +30829,7 @@ const Octokit = Octokit$1.plugin(requestLog, legacyRestEndpointMethods, paginate
 
 async function run() {
     // Get the inputs
+    const apiUrl = coreExports.getInput('api_url', { required: true });
     const draft = coreExports.getInput('draft') === 'true';
     const generateReleaseNotes = coreExports.getInput('generate_release_notes') === 'true';
     /* istanbul ignore next */
@@ -30844,6 +30845,7 @@ async function run() {
     const token = coreExports.getInput('github_token', { required: true });
     // Log the inputs
     coreExports.info('Running action with the following inputs:');
+    coreExports.info(`  apiUrl: ${apiUrl}`);
     coreExports.info(`  draft: ${draft}`);
     coreExports.info(`  generateReleaseNotes: ${generateReleaseNotes}`);
     coreExports.info(`  name: ${name}`);
@@ -30854,7 +30856,7 @@ async function run() {
     coreExports.info(`  tag: ${tag}`);
     coreExports.info(`  target: ${target}`);
     // Create the Octokit client
-    const github = new Octokit({ auth: token });
+    const github = new Octokit({ auth: token, baseUrl: apiUrl });
     try {
         // Create the API options
         const options = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "releaser",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "releaser",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "releaser",
   "description": "Handle releases for GitHub repositories",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "homepage": "https://github.com/issue-ops/releaser#readme",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import type { CreateReleaseOptions, Release } from './interfaces.js'
 
 export async function run(): Promise<void> {
   // Get the inputs
+  const apiUrl = core.getInput('api_url', { required: true })
   const draft: boolean = core.getInput('draft') === 'true'
   const generateReleaseNotes: boolean =
     core.getInput('generate_release_notes') === 'true'
@@ -23,6 +24,7 @@ export async function run(): Promise<void> {
 
   // Log the inputs
   core.info('Running action with the following inputs:')
+  core.info(`  apiUrl: ${apiUrl}`)
   core.info(`  draft: ${draft}`)
   core.info(`  generateReleaseNotes: ${generateReleaseNotes}`)
   core.info(`  name: ${name}`)
@@ -34,7 +36,7 @@ export async function run(): Promise<void> {
   core.info(`  target: ${target}`)
 
   // Create the Octokit client
-  const github: Octokit = new Octokit({ auth: token })
+  const github: Octokit = new Octokit({ auth: token, baseUrl: apiUrl })
 
   try {
     // Create the API options


### PR DESCRIPTION
This pull request introduces support for customizing the GitHub API URL in the `releaser` action. The change adds a new input parameter, `api_url`, and updates the relevant files to handle this input. Additionally, the version of the package has been incremented to reflect the new functionality.